### PR TITLE
Remove unnecessary property def

### DIFF
--- a/homeassistant/components/rfxtrx/light.py
+++ b/homeassistant/components/rfxtrx/light.py
@@ -97,14 +97,6 @@ class RfxtrxLight(RfxtrxDevice, Light, RestoreEntity):
         return self._brightness
 
     @property
-    def device_state_attributes(self):
-        """Return the device state attributes."""
-        attr = {}
-        if self._brightness is not None:
-            attr[ATTR_BRIGHTNESS] = self._brightness
-        return attr
-
-    @property
     def supported_features(self):
         """Flag supported features."""
         return SUPPORT_RFXTRX


### PR DESCRIPTION
## Description:
As discussed with @MartinHJelmare in #30309 the `def device_state_attributes(self):` can be removed, as brightness is already an attribute of light. 

**Related PR:** #30309

## Checklist:
  - [x] The code change is tested and works locally.
  - [x] Local tests pass with `tox`. **Your PR cannot be merged unless tests pass**
  - [x] There is no commented out code in this PR.
  - [x] I have followed the [development checklist][dev-checklist]

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [home-assistant.io](https://github.com/home-assistant/home-assistant.io) **n/a**

If the code communicates with devices, web services, or third-party tools:
  - [ ] [_The manifest file_][manifest-docs] has all fields filled out correctly. Update and include derived files by running `python3 -m script.hassfest`. **n/a**
  - [ ] New or updated dependencies have been added to `requirements_all.txt` by running `python3 -m script.gen_requirements_all`. **n/a**
  - [ ] Untested files have been added to `.coveragerc`. **n/a**

If the code does not interact with devices:
  - [ ] Tests have been added to verify that the new code works. **n/a**

[dev-checklist]: https://developers.home-assistant.io/docs/en/development_checklist.html
[manifest-docs]: https://developers.home-assistant.io/docs/en/creating_integration_manifest.html
